### PR TITLE
DeferredInArrayValidator: Don't cache callback result

### DIFF
--- a/src/DeferredInArrayValidator.php
+++ b/src/DeferredInArrayValidator.php
@@ -35,11 +35,7 @@ class DeferredInArrayValidator extends InArrayValidator
 
     public function getHaystack(): array
     {
-        if (! isset($this->haystack)) {
-            $this->haystack = call_user_func($this->callback);
-        }
-
-        return $this->haystack;
+        return $this->haystack ?? call_user_func($this->callback);
     }
 
     /**


### PR DESCRIPTION
The `CallbackValidator` doesn't as well and we drop the cache of `BaseFormElement::isValid()` [here](https://github.com/Icinga/ipl-html/pull/97).

refs https://github.com/Icinga/ipl-html/pull/88