### PR TITLE
Run validators irrespective of an empty value

### DIFF
--- a/src/BaseValidator.php
+++ b/src/BaseValidator.php
@@ -8,31 +8,4 @@ use ipl\Stdlib\Messages;
 abstract class BaseValidator implements Validator
 {
     use Messages;
-
-    /** @var bool Whether to validate an empty value */
-    protected $validateEmpty = false;
-
-    /**
-     * Get whether to validate an empty value
-     *
-     * @return bool
-     */
-    public function validateEmpty(): bool
-    {
-        return $this->validateEmpty;
-    }
-
-    /**
-     * Set whether to validate an empty value
-     *
-     * @param bool $validateEmpty
-     *
-     * @return $this
-     */
-    public function setValidateEmpty(bool $validateEmpty = true): self
-    {
-        $this->validateEmpty = $validateEmpty;
-
-        return $this;
-    }
 }

--- a/src/BaseValidator.php
+++ b/src/BaseValidator.php
@@ -35,16 +35,4 @@ abstract class BaseValidator implements Validator
 
         return $this;
     }
-
-    /**
-     * Get whether the given value is empty
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    public function isEmpty($value): bool
-    {
-        return $value === '' || $value === [] || $value === null;
-    }
 }

--- a/src/CallbackValidator.php
+++ b/src/CallbackValidator.php
@@ -22,8 +22,6 @@ namespace ipl\Validator;
  */
 class CallbackValidator extends BaseValidator
 {
-    protected $validateEmpty = true;
-
     /** @var callable Validation callback */
     protected $callback;
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -140,7 +140,7 @@ class ValidatorChain implements Countable, IteratorAggregate, Validator
 
                 $validator = $this->createValidator($name, $validator);
 
-                if ($validateEmpty !== null && $validator instanceof BaseValidator) {
+                if ($validateEmpty !== null) {
                     $validator->setValidateEmpty($validateEmpty);
                 }
             }
@@ -276,11 +276,7 @@ class ValidatorChain implements Countable, IteratorAggregate, Validator
         $valid = true;
 
         foreach ($this as $validator) {
-            if (empty($value) && $validator instanceof BaseValidator && ! $validator->validateEmpty()) {
-                continue;
-            }
-
-            if ($validator->isValid($value)) {
+            if ((empty($value) && ! $validator->validateEmpty()) || $validator->isValid($value)) {
                 continue;
             }
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -276,7 +276,7 @@ class ValidatorChain implements Countable, IteratorAggregate, Validator
         $valid = true;
 
         foreach ($this as $validator) {
-            if ($validator instanceof BaseValidator && ! $validator->validateEmpty() && $validator->isEmpty($value)) {
+            if (empty($value) && $validator instanceof BaseValidator && ! $validator->validateEmpty()) {
                 continue;
             }
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -98,7 +98,7 @@ class ValidatorChain implements Countable, IteratorAggregate, Validator
 
         foreach ($validators as $name => $validator) {
             $breakChainOnFailure = false;
-            $validateEmpty = null;
+
             if (! $validator instanceof Validator) {
                 if (is_int($name)) {
                     if (! is_array($validator)) {
@@ -130,19 +130,9 @@ class ValidatorChain implements Countable, IteratorAggregate, Validator
 
                         unset($validator['break_chain_on_failure']);
                     }
-
-                    if (isset($validator['validate_empty'])) {
-                        $validateEmpty = $validator['validate_empty'];
-
-                        unset($validator['validate_empty']);
-                    }
                 }
 
                 $validator = $this->createValidator($name, $validator);
-
-                if ($validateEmpty !== null) {
-                    $validator->setValidateEmpty($validateEmpty);
-                }
             }
 
             $this->add($validator, $breakChainOnFailure);
@@ -276,7 +266,7 @@ class ValidatorChain implements Countable, IteratorAggregate, Validator
         $valid = true;
 
         foreach ($this as $validator) {
-            if ((empty($value) && ! $validator->validateEmpty()) || $validator->isValid($value)) {
+            if ($validator->isValid($value)) {
                 continue;
             }
 

--- a/tests/ValidatorChainTest.php
+++ b/tests/ValidatorChainTest.php
@@ -3,8 +3,6 @@
 namespace ipl\Tests\Validator;
 
 use InvalidArgumentException;
-use ipl\I18n\NoopTranslator;
-use ipl\I18n\StaticTranslator;
 use ipl\Validator\CallbackValidator;
 use ipl\Validator\ValidatorChain;
 
@@ -213,45 +211,6 @@ class ValidatorChainTest extends TestCase
 
         $this->assertFalse($validators->isValid('value'));
         $this->assertSame(['Validation failed'], $validators->getMessages());
-    }
-
-    public function testValidateEmptyFlag()
-    {
-        $validators = (new ValidatorChain())
-            ->addValidators([
-                new CallbackValidator(function ($value, CallbackValidator $validator) {
-                    $validator->addMessage('This validator should get called');
-                    return false;
-                })
-            ]);
-
-        $this->assertFalse($validators->isValid(null));
-        $this->assertSame(['This validator should get called'], $validators->getMessages());
-
-        $validators = (new ValidatorChain())
-            ->addValidators([
-                (new CallbackValidator(function ($value, CallbackValidator $validator) {
-                    $validator->addMessage('This validator should not get called');
-                    return false;
-                }))
-                ->setValidateEmpty(false)
-            ]);
-
-        $this->assertTrue($validators->isValid(null));
-        $this->assertSame([], $validators->getMessages());
-
-        $validators = (new ValidatorChain())
-            ->addValidators(['DateTime' => null]);
-
-        $this->assertTrue($validators->isValid(null));
-        $this->assertSame([], $validators->getMessages());
-
-        StaticTranslator::$instance = new NoopTranslator();
-        $validators = (new ValidatorChain())
-            ->addValidators(['DateTime' => ['validate_empty' => true]]);
-
-        $this->assertFalse($validators->isValid(null));
-        $this->assertSame(['Invalid date/time given.'], $validators->getMessages());
     }
 
     public function testIsValidClearsMessages()

--- a/tests/ValidatorChainTest.php
+++ b/tests/ValidatorChainTest.php
@@ -254,24 +254,6 @@ class ValidatorChainTest extends TestCase
         $this->assertSame(['Invalid date/time given.'], $validators->getMessages());
     }
 
-    public function testOnlyEmptyValuesAreSkippedIfValidateEmptyIsFalse()
-    {
-        $validators = (new ValidatorChain())
-            ->addValidators([
-                (new CallbackValidator(function () {
-                    return false;
-                }))->setValidateEmpty(false)
-            ]);
-
-        $this->assertFalse($validators->isValid('0'), "`'0'` is not validated");
-        $this->assertFalse($validators->isValid(0), '`0` is not validated');
-        $this->assertFalse($validators->isValid(false), '`false` is not validated');
-
-        $this->assertTrue($validators->isValid(null), '`null` is validated');
-        $this->assertTrue($validators->isValid(''), "'' is validated");
-        $this->assertTrue($validators->isValid([]), '`[]` is validated');
-    }
-
     public function testIsValidClearsMessages()
     {
         $validators = (new ValidatorChain())

--- a/tests/ValidatorChainTest.php
+++ b/tests/ValidatorChainTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Validator;
 use InvalidArgumentException;
 use ipl\Validator\CallbackValidator;
 use ipl\Validator\ValidatorChain;
+use LogicException;
 
 class ValidatorChainTest extends TestCase
 {
@@ -296,5 +297,20 @@ class ValidatorChainTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         (new ValidatorChain())->addValidators($spec);
+    }
+
+    public function testValidatorsWithoutSupportForEmptyValuesThrow()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('This is expected');
+
+        $chain = (new ValidatorChain())
+            ->add(new CallbackValidator(function ($value) {
+                if ($value === null) {
+                    throw new LogicException('This is expected');
+                }
+            }));
+
+        $chain->isValid(null);
     }
 }


### PR DESCRIPTION
Reverts everything related to validation of empty values. Whether validation runs or not is now controlled by form elements, as they know what an existing value is or not.

Though, this means that all current validators **may** run explicitly with empty values passed to them. This is currently not accounted for in any implementation. But tests succeed.