### PR TITLE
Raise `ipl/*` requirements to adopt strict typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this library are documented in this file.
 
 ## [Unreleased]
 
-- **Breaking** Raise minimum PHP version to 8.0 (#42)
+- **Breaking** Raise minimum PHP version to 8.2 (#44)
 - Add `RegexMatchValidator` to validate values against a
   regular expression (#19)
 - Add `RegexSyntaxValidator` to validate that a string is a
   syntactically valid regular expression (#42)
+- Add strict type declarations (#39, #44)
 - Support PHP 8.5 (#38)
-- Add return, parameter, and property types (#39)
 
 ## [0.5.0] - 2023-03-22
 

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
   "type": "library",
   "homepage": "https://github.com/Icinga/ipl-validator",
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.2",
     "ext-mbstring": "*",
     "ext-openssl": "*",
-    "ipl/i18n": ">=0.2.0",
-    "ipl/stdlib": ">=0.12.0",
+    "ipl/i18n": ">=1.0.0",
+    "ipl/stdlib": ">=0.15.0",
     "psr/http-message": "^1.1"
   },
   "require-dev": {


### PR DESCRIPTION
Also raise minimum PHP version to 8.2, as the updated `ipl/*` packages require
PHP 8.2+.